### PR TITLE
Fix setup.py to match it's current paster template

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
 	url='http://okfn.org',
 	license='GPL',
 	packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-	namespace_packages=['ckanext', 'ckanext.disqus'],
+	namespace_packages=['ckanext'],
 	include_package_data=True,
 	zip_safe=False,
 	install_requires=[


### PR DESCRIPTION
Fixes the corresponding issue with this extension as described here: https://github.com/ckan/ckanext-harvest/pull/278