### PR TITLE
inconsistent name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys, os
 version = '0.1'
 
 setup(
-	name='disqus',
+	name='ckanext-disqus',
 	version=version,
 	description="Disqus commenting feature for CKAN",
 	long_description="""\

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
 	entry_points=\
 	"""
     [ckan.plugins]
-	disqus = ckanext.disqus.plugin:Disqus
+	ckanext-disqus = ckanext.disqus.plugin:Disqus
 	""",
 )

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,6 @@ setup(
 	entry_points=\
 	"""
     [ckan.plugins]
-	ckanext-disqus = ckanext.disqus.plugin:Disqus
+	disqus = ckanext.disqus.plugin:Disqus
 	""",
 )


### PR DESCRIPTION
I tired to install the image for CKAN 2.9 but I have an error:

`> [extbuild 4/2] RUN set -ex && pip wheel --wheel-dir=/wheels git+https://github.com/ckan/ckanext-disqus@master#egg=ckanext-disqus:
#7 0.339 + pip wheel '--wheel-dir=/wheels' 'git+https://github.com/ckan/ckanext-disqus@master#egg=ckanext-disqus'
#7 1.250 Collecting ckanext-disqus
#7 1.251   Cloning https://github.com/ckan/ckanext-disqus (to revision master) to /tmp/pip-wheel-x6wpzy5o/ckanext-disqus_ab5d493d397f46f8be382691ac6fcc46
#7 1.264   Running command git clone --filter=blob:none --quiet https://github.com/ckan/ckanext-disqus /tmp/pip-wheel-x6wpzy5o/ckanext-disqus_ab5d493d397f46f8be382691ac6fcc46
#7 2.273   Resolved https://github.com/ckan/ckanext-disqus to commit d3fcdb727d0f0647a36bd46c31802bb7818d4802
#7 2.274   Preparing metadata (setup.py): started
#7 2.579   Preparing metadata (setup.py): finished with status 'done'
#7 2.580   WARNING: Generating metadata for package ckanext-disqus produced metadata for project name disqus. Fix your #egg=ckanext-disqus fragments.
#7 2.581 Discarding git+https://github.com/ckan/ckanext-disqus@master#egg=ckanext-disqus: Requested disqus from git+https://github.com/ckan/ckanext-disqus@master#egg=ckanext-disqus has inconsistent name: filename has 'ckanext-disqus', but metadata has 'disqus'
#7 2.762 ERROR: Could not find a version that satisfies the requirement ckanext-disqus (unavailable) (from versions: none)
#7 2.763 ERROR: No matching distribution found for ckanext-disqus (unavailable)
#7 2.931
#7 2.931 [notice] A new release of pip available: 22.1.2 -> 22.3.1
#7 2.931 [notice] To update, run: pip install --upgrade pip
------
executor failed running [/bin/sh -c set -ex && pip wheel --wheel-dir=/wheels git+https://github.com/ckan/ckanext-disqus@${CKAN_EXT_DISQUS_VERSION}#egg=ckanext-disqus]: exit code: 1`

Changing name in setup.py seems that solved the problem